### PR TITLE
Fix legacy prop layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -214,7 +214,7 @@ export default function Home() {
       </section>
       <section id="schedule" className="text-center">
         <div className="bg-img">
-          <Image src={scheduleBG} alt="ThunderPlains Badge" layout="fill" />
+          <Image src={scheduleBG} alt="ThunderPlains Badge" fill />
         </div>
         <h2>Schedule</h2>
 


### PR DESCRIPTION
Updates `layout=fill` to just `fill` based on Next.js 13 changes.

Closes #25.